### PR TITLE
bluebinder: gbinder reader expects gsize for size and count

### DIFF
--- a/bluebinder.c
+++ b/bluebinder.c
@@ -397,7 +397,7 @@ bluebinder_callbacks_transact(
 
             return gbinder_local_reply_append_int32(gbinder_local_object_new_reply(obj), 0);
         } else if (code == 2 || code == 3 || code == 4) {
-            unsigned int count, elemsize;
+            gsize count, elemsize;
             GBinderReader reader;
             const uint8_t *vec;
             uint8_t *packet;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+bluebinder (1.0.1) unstable; urgency=low
+
+  * Fix arm64 unexpected array element size
+
+ -- Erfan Abdi <erfangplus@gmail.com> Mon May 4 04:57:18 2020 +0000
+
 bluebinder (1.0.0) unstable; urgency=low
 
   * Huong Tram is my favorite singer


### PR DESCRIPTION
* Fixes bluebinder on arm64 builds