### PR TITLE
upstart: Stop service at runlevels 0 and 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@
 DESTDIR ?= /
 
 build:
-	gcc -Wall -O3 -flto bluebinder.c `pkg-config --cflags libgbinder` `pkg-config --libs libgbinder` -o bluebinder
+	gcc -Wall -O3 -flto bluebinder.c \
+		`pkg-config --cflags glib-2.0` `pkg-config --libs glib-2.0` \
+		`pkg-config --cflags libgbinder` `pkg-config --libs libgbinder` -o bluebinder
 
 install:
 	mkdir -p $(DESTDIR)/usr/sbin

--- a/bluebinder.conf
+++ b/bluebinder.conf
@@ -3,6 +3,7 @@
 description "Bluebinder"
 
 start on started lightdm
+stop on runlevel [06]
 
 respawn
 


### PR DESCRIPTION
Should fix the system-watchdog triggering a reboot whenever
the bluebinder service fails to stop cleanly at shutdown.